### PR TITLE
Fix duplicate timestamp fields in Ticket model

### DIFF
--- a/app/services/report/models.py
+++ b/app/services/report/models.py
@@ -89,8 +89,6 @@ class Ticket(Model):
     report_reason = fields.TextField(null=True)  # 举报理由
 
     admin_remark = fields.TextField(null=True)  # 处理备注
-    created_at = fields.DatetimeField(auto_now_add=True)  # 创建时间
-    updated_at = fields.DatetimeField(auto_now=True)  # 更新时间
 
     class Meta:
         table = "ticket"  # 数据表名


### PR DESCRIPTION
## Summary
- clean up redundant `created_at` and `updated_at` fields from `Ticket` model

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c498a6b1c832ab457238a67c4a72a