### PR TITLE
添加邮箱验证码功能，支持通过验证码进行邮箱验证，并更新相关描述和逻辑

### DIFF
--- a/app/router/auth.py
+++ b/app/router/auth.py
@@ -239,13 +239,7 @@ async def verify_code(code: str):
         )
     
     # 获取验证码数据
-    verify_data_str: str = await redis_client.get(f"verify_code:{code}")
-    if verify_data_str is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="验证码无效或已过期"
-        )
-    
-    verify_data: dict = json.loads(verify_data_str)
+    verify_data = await get_code_data(code)
     
     # 更新验证码状态为已验证，延长有效期至24小时
     await redis_client.setex(

--- a/app/router/auth.py
+++ b/app/router/auth.py
@@ -360,10 +360,6 @@ async def register(
                 status_code=status.HTTP_400_BAD_REQUEST, detail="验证码必须是6位数字"
             )
         verify_data = await get_code_data(register_data.code)
-        if verify_data is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="验证码无效或已过期"
-            )
         if not verify_data["verified"]:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT, detail="验证码未被验证"

--- a/app/services/auth/schemas.py
+++ b/app/services/auth/schemas.py
@@ -25,10 +25,15 @@ class RegisterRequest(CaptchaBase):
         title="显示名称",
         description="用户的显示名称，长度为 4-16 位",
     )
-    token: str = Field(
-        ...,
+    token: str | None = Field(
+        None,
         title="验证令牌",
-        description="用户注册的验证令牌",
+        description="用户注册的验证令牌（使用邮件链接验证时）",
+    )
+    code: str | None = Field(
+        None,
+        title="验证码",
+        description="6位数字验证码（使用验证码验证时）",
     )
 
 

--- a/template/email_code_verify.html
+++ b/template/email_code_verify.html
@@ -62,6 +62,7 @@
                                                 <td>
                                                     <img data-id="react-email-img"
                                                         src="https://fastly.jsdelivr.net/gh/mx-space/docs-images@master/images/chichi-1.jpeg"
+                                                        alt="Decorative blurred image of Chichi character"
                                                         style="
                         display: block;
                         outline: none;

--- a/template/email_code_verify.html
+++ b/template/email_code_verify.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html
+    PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="en">
+
+<head data-id="__react-email-head">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+
+<body data-id="__react-email-body" style="
+      background-color: rgb(255, 255, 255);
+      margin-top: auto;
+      margin-bottom: auto;
+      margin-left: auto;
+      margin-right: auto;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+        Segoe UI, Roboto, Helvetica Neue, Arial, Noto Sans, sans-serif,
+        Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+      padding: 0.5rem;
+    ">
+    <table align="center" width="100%" data-id="__react-email-container" role="presentation" cellspacing="0"
+        cellpadding="0" border="0" style="
+        max-width: 100%;
+        margin-top: 0px;
+        margin-bottom: 0px;
+        margin-left: auto;
+        margin-right: auto;
+      ">
+        <tbody>
+            <tr style="width: 100%">
+                <td>
+                    <table align="center" width="100%" data-id="react-email-section" border="0" cellpadding="0"
+                        cellspacing="0" role="presentation" style="
+        border-width: 1px;
+        border-style: solid;
+        box-shadow: 0 0 #0000, 0 0 #0000, 0 4px 6px -1px rgb(0, 0, 0, 0.1),
+          0 2px 4px -2px rgb(0, 0, 0, 0.1);
+        border-radius: 0.25rem;
+        margin-top: 40px;
+        margin-bottom: 40px;
+        margin-left: auto;
+        margin-right: auto;
+        padding: 20px;
+        width: 550px;
+        border-color: rgb(14, 165, 233);
+        position: relative;
+        overflow: hidden;
+      ">
+                        <tbody>
+                            <tr style="width: 100%">
+                                <td>
+                                    <table align="center" width="100%" data-id="react-email-section" border="0"
+                                        cellpadding="0" cellspacing="0" role="presentation" style="
+                position: absolute;
+                top: 0px;
+                right: 0px;
+                bottom: 0px;
+                left: 0px;
+                pointer-events: none;
+              ">
+                                        <tbody>
+                                            <tr>
+                                                <td>
+                                                    <img data-id="react-email-img"
+                                                        src="https://fastly.jsdelivr.net/gh/mx-space/docs-images@master/images/chichi-1.jpeg"
+                                                        style="
+                        display: block;
+                        outline: none;
+                        border: none;
+                        text-decoration: none;
+                        mask-image: linear-gradient(
+                          to bottom,
+                          rgba(0, 0, 0, 1) 0%,
+                          transparent 100%
+                        );
+                        -webkit-mask-image: linear-gradient(
+                          to bottom,
+                          rgba(0, 0, 0, 1) 0%,
+                          transparent 100%
+                        );
+                        object-fit: contain;
+                        max-width: 100%;
+                        opacity: 0.2;
+                        filter: blur(16px);
+                      " />
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    <table align="center" width="100%" data-id="react-email-section" border="0"
+                                        cellpadding="0" cellspacing="0" role="presentation"
+                                        style="margin-top: 32px">
+                                        <tbody>
+                                            <tr>
+                                                <td>
+                                                    <img data-id="react-email-img"
+                                                        src="https://mscpo.crashvibe.cn/logo.webp" style="
+                        display: block;
+                        outline: none;
+                        border: none;
+                        text-decoration: none;
+                        margin-top: 0px;
+                        margin-bottom: 0px;
+                        margin-left: auto;
+                        margin-right: auto;
+                        border-radius: 0.75rem;
+                        height: 3rem;
+                        width: 3rem;
+                      " />
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    <h1 data-id="react-email-heading" style="
+                color: rgb(0, 0, 0);
+                font-size: 18px;
+                font-weight: 400;
+                text-align: center;
+                padding: 0px;
+                margin-top: 30px;
+                margin-bottom: 30px;
+                margin-left: 0px;
+                margin-right: 0px;
+              ">
+                                        Minecraft Server 集体宣传组织 (MSCPO)
+                                    </h1>
+                                    <strong data-id="react-email-text" style="
+                font-size: 14px;
+                line-height: 24px;
+                margin: 16px 0;
+                color: rgb(0, 0, 0);
+              ">
+                                        您的验证码是:
+                                        <table align="center" width="100%" data-id="react-email-section" border="0"
+                                            cellpadding="0" cellspacing="0" role="presentation" style="
+                background-color: rgb(243, 244, 246);
+                border-radius: 0.75rem;
+                padding-left: 1rem;
+                padding-right: 1rem;
+              ">
+                                            <tbody>
+                                                <tr>
+                                                    <td>
+                                                        <p data-id="react-email-text" style="
+                        font-size: 24px;
+                        line-height: 24px;
+                        margin: 16px 0;
+                        color: rgb(14, 165, 233);
+                        text-align: center;
+                        font-weight: bold;
+                        letter-spacing: 4px;
+                      ">
+                                                            {{code}}
+                                                        </p>
+                                                    </td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </strong>
+                                    <p data-id="react-email-text" style="
+                font-size: 14px;
+                line-height: 24px;
+                margin: 16px 0;
+                color: rgb(0, 0, 0);
+              ">
+                                        请在验证页面输入此验证码完成邮箱验证。验证码有效期为 15 分钟。
+                                    </p>
+                                    <hr data-id="react-email-hr" style="
+                width: 100%;
+                border: none;
+                border-top: 1px solid #eaeaea;
+                border-width: 1px;
+                border-style: solid;
+                border-color: rgb(234, 234, 234);
+                margin-top: 26px;
+                margin-bottom: 26px;
+                margin-left: 0px;
+                margin-right: 0px;
+              " />
+                                    <table align="center" width="100%" data-id="react-email-section" border="0"
+                                        cellpadding="0" cellspacing="0" role="presentation">
+                                        <tbody>
+                                            <tr>
+                                                <td>
+                                                    <p data-id="react-email-text" style="
+                        font-size: 12px;
+                        line-height: 24px;
+                        margin: 16px 0;
+                        color: rgb(107, 114, 128);
+                      ">
+                                                        {% if from_who %}
+                                                        "{{ sentence }}" —— {{ sentence_from }}《{{ from_who }}》
+                                                        {% else %}
+                                                        "{{ sentence }}" —— {{ sentence_from }}
+                                                        {% endif %}
+                                                    </p>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    <table align="center" width="100%" data-id="react-email-section" border="0"
+                                        cellpadding="0" cellspacing="0" role="presentation" style="margin-top: 1rem">
+                                        <tbody>
+                                            <tr>
+                                                <td>
+                                                    <p data-id="react-email-text" style="
+                        font-size: 10px;
+                        line-height: 24px;
+                        margin: 16px 0;
+                        text-align: center;
+                        color: rgb(156, 163, 175);
+                      ">
+                                                        本邮件为系统自动发送，请勿直接回复~ <br />©{{fullyear}} Copyright MSCPO
+                                                    </p>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+
+</html>


### PR DESCRIPTION
## 修改 /verifyemail 接口

- 添加了 ?by=code 查询参数支持
- 当携带该参数时，向目标邮箱发送6位数验证码
- 保持了原有功能的向后兼容性

## 新增 /verify/code/{code} 接口

- 验证6位数验证码
- 验证成功后标记为已验证，延长有效期至24小时
- 完整的错误处理和格式验证

## 复制和修改模板

- 创建了新的验证码邮件模板 email_code_verify.html
- 保持了与原模板一致的设计风格